### PR TITLE
Save the split size. (#48)

### DIFF
--- a/src/control/SettingsControler.java
+++ b/src/control/SettingsControler.java
@@ -275,6 +275,7 @@ public class SettingsControler extends ControlBase implements Serializable, Acti
         JSpinner jspiner = (JSpinner) ce.getSource();
         int sizeValue = (Integer) jspiner.getValue();
         SettingsManager.getInstance().setConfig("splitSize", String.valueOf(sizeValue));
+        DispatchManager.getInstance().sendDispatchForMsg(DispatchManager.SPLIT_PANE_CHANGED, String.valueOf(sizeValue));       
     }
 
     @Override

--- a/src/control/WorldControler.java
+++ b/src/control/WorldControler.java
@@ -111,6 +111,7 @@ public class WorldControler extends ControlBase implements Serializable, ActionL
         registerDispatchManagerForMsg(DispatchManager.STATUS_BAR_MSG);
         registerDispatchManagerForMsg(DispatchManager.ACTIONS_MAP_REDRAW);
         registerDispatchManagerForMsg(DispatchManager.SWITCH_PORTRAIT_PANEL);
+        registerDispatchManagerForMsg(DispatchManager.SPLIT_PANE_CHANGED);
     }
 
     @Override
@@ -949,6 +950,8 @@ public class WorldControler extends ControlBase implements Serializable, ActionL
             getGui().setStatusMsg(msg);
         } else if (msgName == DispatchManager.SWITCH_PORTRAIT_PANEL) {
             gui.getDisplayPortraits().setSelected(msg.equals("1"));
+        } else if (msgName == DispatchManager.SPLIT_PANE_CHANGED) {
+            gui.setSplitPaneValue(Integer.parseInt(msg));
         }
     }
 

--- a/src/control/support/DispatchManager.java
+++ b/src/control/support/DispatchManager.java
@@ -49,6 +49,7 @@ public class DispatchManager implements Serializable {
     public static final int WINDOWS_CLOSING = 17;
     public static final int WINDOWS_MAXIMIZING = 18;
     public static final int WINDOWS_MINIMIZING = 19;
+    public static final int SPLIT_PANE_CHANGED = 20;
 
     private DispatchManager() {
     }

--- a/src/gui/MainResultWindowGui.form
+++ b/src/gui/MainResultWindowGui.form
@@ -30,9 +30,9 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
               <Component id="infoPanel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="splitMainPanel" pref="648" max="32767" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="statusBar" max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -533,6 +533,9 @@
         </Property>
         <Property name="oneTouchExpandable" type="boolean" value="true"/>
       </Properties>
+      <Events>
+        <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="splitMainPanelPropertyChange"/>
+      </Events>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
       <SubComponents>

--- a/src/gui/MainResultWindowGui.java
+++ b/src/gui/MainResultWindowGui.java
@@ -6,7 +6,6 @@
 package gui;
 
 import business.ImageManager;
-import business.MapaManager;
 import control.MapaControler;
 import control.WorldControler;
 import control.facade.WorldFacadeCounselor;
@@ -19,22 +18,16 @@ import java.awt.Dimension;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.io.Serializable;
-import java.util.SortedMap;
 import javax.swing.GroupLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JToggleButton;
 import javax.swing.plaf.basic.BasicSplitPaneUI;
-import model.Cenario;
-import model.Local;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import persistence.local.ListFactory;
 import persistenceCommons.BundleManager;
 import persistenceCommons.SettingsManager;
 import persistenceCommons.SysApoio;
-import radialMenu.mapmenu.MapMenuManager;
-import radialMenu.worldBuilder.WorldBuilderMenuManager;
 
 /**
  *
@@ -42,7 +35,7 @@ import radialMenu.worldBuilder.WorldBuilderMenuManager;
  */
 public class MainResultWindowGui extends javax.swing.JPanel implements Serializable {
 
-    private static final Log log = LogFactory.getLog(MainResultWindowGui.class);
+    private static final Log LOG = LogFactory.getLog(MainResultWindowGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private final WorldControler wc = new WorldControler(this);
     private TabPersonagensGui tabPersonagem;
@@ -52,6 +45,7 @@ public class MainResultWindowGui extends javax.swing.JPanel implements Serializa
 
     /**
      * Creates new form MainResultWindowGui
+     * @param autoLoad 
      */
     public MainResultWindowGui(String autoLoad) {
         this.settingsManager = SettingsManager.getInstance();
@@ -384,6 +378,11 @@ public class MainResultWindowGui extends javax.swing.JPanel implements Serializa
         splitMainPanel.setAutoscrolls(true);
         splitMainPanel.setMinimumSize(new java.awt.Dimension(0, 0));
         splitMainPanel.setOneTouchExpandable(true);
+        splitMainPanel.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                splitMainPanelPropertyChange(evt);
+            }
+        });
 
         jlLeft.setToolTipText("Open.");
         splitMainPanel.setLeftComponent(jlLeft);
@@ -433,6 +432,16 @@ public class MainResultWindowGui extends javax.swing.JPanel implements Serializa
                 .addComponent(statusBar, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void splitMainPanelPropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_splitMainPanelPropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitWidth = evt.getNewValue().toString();
+            LOG.debug("Split pane divisor modified to " + splitWidth + " px.");
+            if (Integer.parseInt(splitWidth) > 0)
+                SettingsManager.getInstance().setConfig("splitSize", splitWidth);
+        } 
+    }//GEN-LAST:event_splitMainPanelPropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.Box.Filler filler1;
     private javax.swing.Box.Filler filler2;
@@ -474,7 +483,7 @@ public class MainResultWindowGui extends javax.swing.JPanel implements Serializa
     // End of variables declaration//GEN-END:variables
 
     public void iniciaConfig() {
-        log.info(labels.getString("INICIALIZANDO.GUI"));
+        LOG.info(labels.getString("INICIALIZANDO.GUI"));
         //infopanel
         this.labelCenario.setText(String.format("%s: %s", labels.getString("CENARIO"), wc.getCenarioNome()));
         if (wc.isGameOver()) {
@@ -559,7 +568,7 @@ public class MainResultWindowGui extends javax.swing.JPanel implements Serializa
         // divide a janela ao meio = -1
         //        this.splitMainPanel.setDividerLocation(55555);
         int splitWid = SysApoio.parseInt(SettingsManager.getInstance().getConfig("splitSize", "660"));
-        this.splitMainPanel.setDividerLocation(splitWid);
+        this.splitMainPanel.setDividerLocation(splitWid);        
         doMinimizeMap();
     }
 
@@ -672,6 +681,10 @@ public class MainResultWindowGui extends javax.swing.JPanel implements Serializa
 
     public JToggleButton getDisplayPortraits() {
         return this.toggleDisplayPortrait;
+    }
+    
+    public void setSplitPaneValue(int value) {
+        this.splitMainPanel.setDividerLocation(value);
     }
         
 }

--- a/src/gui/tabs/TabAcoesGui.form
+++ b/src/gui/tabs/TabAcoesGui.form
@@ -127,12 +127,17 @@
             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
               <Border info="null"/>
             </Property>
-            <Property name="dividerLocation" type="int" value="200"/>
+            <Property name="dividerLocation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="SettingsManager.getInstance().getConfigAsInt(&quot;actionsSplitSize&quot;, &quot;200&quot;)" type="code"/>
+            </Property>
             <Property name="dividerSize" type="int" value="3"/>
             <Property name="orientation" type="int" value="0"/>
             <Property name="resizeWeight" type="double" value="0.5"/>
             <Property name="autoscrolls" type="boolean" value="true"/>
           </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jSplitPane1PropertyChange"/>
+          </Events>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>
@@ -184,7 +189,7 @@
                 </DimensionLayout>
                 <DimensionLayout dim="1">
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <EmptySpace min="0" pref="209" max="32767" attributes="0"/>
+                      <EmptySpace min="0" pref="198" max="32767" attributes="0"/>
                   </Group>
                 </DimensionLayout>
               </Layout>

--- a/src/gui/tabs/TabAcoesGui.java
+++ b/src/gui/tabs/TabAcoesGui.java
@@ -23,7 +23,7 @@ import persistenceCommons.SettingsManager;
  */
 public final class TabAcoesGui extends TabBase {
 
-    private static final Log log = LogFactory.getLog(TabAcoesGui.class);
+    private static final Log LOG = LogFactory.getLog(TabAcoesGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private AcaoControler acaoControl;
     private final SubTabTextArea stResults = new SubTabTextArea();
@@ -79,11 +79,16 @@ public final class TabAcoesGui extends TabBase {
         qtAcoes.setText(labels.getString("QTD")); // NOI18N
 
         jSplitPane1.setBorder(null);
-        jSplitPane1.setDividerLocation(200);
+        jSplitPane1.setDividerLocation(SettingsManager.getInstance().getConfigAsInt("actionsSplitSize", "200"));
         jSplitPane1.setDividerSize(3);
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
         jSplitPane1.setResizeWeight(0.5);
         jSplitPane1.setAutoscrolls(true);
+        jSplitPane1.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                jSplitPane1PropertyChange(evt);
+            }
+        });
 
         jScrollPane3.setBorder(null);
 
@@ -129,7 +134,7 @@ public final class TabAcoesGui extends TabBase {
         );
         jpResultLayout.setVerticalGroup(
             jpResultLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 209, Short.MAX_VALUE)
+            .addGap(0, 198, Short.MAX_VALUE)
         );
 
         jSplitPane1.setBottomComponent(jpResult);
@@ -182,6 +187,15 @@ public final class TabAcoesGui extends TabBase {
             .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void jSplitPane1PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jSplitPane1PropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitHeight = evt.getNewValue().toString();
+            LOG.debug("Split actions pane divisor modified to " + splitHeight + " px.");
+            SettingsManager.getInstance().setConfig("actionsSplitSize", splitHeight);            
+        } 
+    }//GEN-LAST:event_jSplitPane1PropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox comboFiltro;
     private javax.swing.JLabel jLabel2;

--- a/src/gui/tabs/TabArtefatosGui.form
+++ b/src/gui/tabs/TabArtefatosGui.form
@@ -113,9 +113,14 @@
         </Component>
         <Container class="javax.swing.JSplitPane" name="jSplitPane1">
           <Properties>
-            <Property name="dividerLocation" type="int" value="200"/>
+            <Property name="dividerLocation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="SysApoio.parseInt(SettingsManager.getInstance().getConfig(&quot;itemsSplitSize&quot;, &quot;200&quot;))" type="code"/>
+            </Property>
             <Property name="orientation" type="int" value="0"/>
           </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jSplitPane1PropertyChange"/>
+          </Events>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>

--- a/src/gui/tabs/TabArtefatosGui.java
+++ b/src/gui/tabs/TabArtefatosGui.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.LogFactory;
 import persistence.local.WorldManager;
 import persistenceCommons.BundleManager;
 import persistenceCommons.SettingsManager;
+import persistenceCommons.SysApoio;
 
 /**
  *
@@ -28,7 +29,7 @@ import persistenceCommons.SettingsManager;
  */
 public class TabArtefatosGui extends TabBase implements Serializable {
 
-    private static final Log log = LogFactory.getLog(TabArtefatosGui.class);
+    private static final Log LOG = LogFactory.getLog(TabArtefatosGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private final ArtefatoControler artefatoControl;
 
@@ -91,8 +92,13 @@ public class TabArtefatosGui extends TabBase implements Serializable {
 
         jLabel3.setText(labels.getString("LISTAR:")); // NOI18N
 
-        jSplitPane1.setDividerLocation(200);
+        jSplitPane1.setDividerLocation(SysApoio.parseInt(SettingsManager.getInstance().getConfig("itemsSplitSize", "200")));
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
+        jSplitPane1.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                jSplitPane1PropertyChange(evt);
+            }
+        });
 
         listaHistoria.setEditable(false);
         listaHistoria.setBorder(null);
@@ -185,6 +191,15 @@ public class TabArtefatosGui extends TabBase implements Serializable {
             .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void jSplitPane1PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jSplitPane1PropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitHeight = evt.getNewValue().toString();
+            LOG.debug("Split items pane divisor modified to " + splitHeight + " px.");
+            SettingsManager.getInstance().setConfig("itemsSplitSize", splitHeight);
+        } 
+    }//GEN-LAST:event_jSplitPane1PropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox comboFiltro;
     private javax.swing.JLabel jLabel2;

--- a/src/gui/tabs/TabCidadesGui.form
+++ b/src/gui/tabs/TabCidadesGui.form
@@ -96,9 +96,14 @@
             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
               <Border info="null"/>
             </Property>
-            <Property name="dividerLocation" type="int" value="200"/>
+            <Property name="dividerLocation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="SysApoio.parseInt(SettingsManager.getInstance().getConfig(&quot;citySplitSize&quot;, &quot;200&quot;))" type="code"/>
+            </Property>
             <Property name="orientation" type="int" value="0"/>
           </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jSplitPane1PropertyChange"/>
+          </Events>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>

--- a/src/gui/tabs/TabCidadesGui.java
+++ b/src/gui/tabs/TabCidadesGui.java
@@ -31,6 +31,7 @@ import org.apache.commons.logging.LogFactory;
 import persistence.local.WorldManager;
 import persistenceCommons.BundleManager;
 import persistenceCommons.SettingsManager;
+import persistenceCommons.SysApoio;
 import utils.OpenSlotCounter;
 
 /**
@@ -39,7 +40,7 @@ import utils.OpenSlotCounter;
  */
 public class TabCidadesGui extends TabBase implements Serializable, IAcaoGui {
 
-    private static final Log log = LogFactory.getLog(TabCidadesGui.class);
+    private static final Log LOG = LogFactory.getLog(TabCidadesGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private CidadeControler cidadeControl;
     private final CenarioFacade cenarioFacade = new CenarioFacade();
@@ -94,8 +95,13 @@ public class TabCidadesGui extends TabBase implements Serializable, IAcaoGui {
         qtCidades.setText("999");
 
         jSplitPane1.setBorder(null);
-        jSplitPane1.setDividerLocation(200);
+        jSplitPane1.setDividerLocation(SysApoio.parseInt(SettingsManager.getInstance().getConfig("citySplitSize", "200")));
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
+        jSplitPane1.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                jSplitPane1PropertyChange(evt);
+            }
+        });
         jSplitPane1.setRightComponent(detalhesCidade);
 
         jScrollPane3.setBorder(null);
@@ -176,6 +182,15 @@ public class TabCidadesGui extends TabBase implements Serializable, IAcaoGui {
             .addComponent(jPanel1, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void jSplitPane1PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jSplitPane1PropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitHeight = evt.getNewValue().toString();
+            LOG.debug("Split city pane divisor modified to " + splitHeight + " px.");
+            SettingsManager.getInstance().setConfig("citySplitSize", splitHeight);
+        } 
+    }//GEN-LAST:event_jSplitPane1PropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox comboFiltro;
     private javax.swing.JTabbedPane detalhesCidade;

--- a/src/gui/tabs/TabExercitosGui.form
+++ b/src/gui/tabs/TabExercitosGui.form
@@ -119,9 +119,14 @@
             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
               <Border info="null"/>
             </Property>
-            <Property name="dividerLocation" type="int" value="200"/>
+            <Property name="dividerLocation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="SysApoio.parseInt(SettingsManager.getInstance().getConfig(&quot;armySplitSize&quot;, &quot;200&quot;))" type="code"/>
+            </Property>
             <Property name="orientation" type="int" value="0"/>
           </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jSplitPane2PropertyChange"/>
+          </Events>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>

--- a/src/gui/tabs/TabExercitosGui.java
+++ b/src/gui/tabs/TabExercitosGui.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import persistence.local.WorldManager;
 import persistenceCommons.BundleManager;
 import persistenceCommons.SettingsManager;
+import persistenceCommons.SysApoio;
 
 /**
  *
@@ -30,7 +31,7 @@ import persistenceCommons.SettingsManager;
  */
 public class TabExercitosGui extends TabBase implements Serializable {
 
-    private static final Log log = LogFactory.getLog(TabExercitosGui.class);
+    private static final Log LOG = LogFactory.getLog(TabExercitosGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private final ExercitoControler exercitoControl;
 
@@ -135,8 +136,13 @@ public class TabExercitosGui extends TabBase implements Serializable {
         );
 
         jSplitPane2.setBorder(null);
-        jSplitPane2.setDividerLocation(200);
+        jSplitPane2.setDividerLocation(SysApoio.parseInt(SettingsManager.getInstance().getConfig("armySplitSize", "200")));
         jSplitPane2.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
+        jSplitPane2.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                jSplitPane2PropertyChange(evt);
+            }
+        });
 
         jScrollPane3.setBorder(null);
 
@@ -240,6 +246,15 @@ public class TabExercitosGui extends TabBase implements Serializable {
             .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void jSplitPane2PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jSplitPane2PropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitHeight = evt.getNewValue().toString();
+            LOG.debug("Split army pane divisor modified to " + splitHeight + " px.");
+            SettingsManager.getInstance().setConfig("armySplitSize", splitHeight);
+        } 
+    }//GEN-LAST:event_jSplitPane2PropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox comboFiltro;
     private javax.swing.JLabel jLabel1;

--- a/src/gui/tabs/TabFeiticosGui.form
+++ b/src/gui/tabs/TabFeiticosGui.form
@@ -112,9 +112,14 @@
             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
               <Border info="null"/>
             </Property>
-            <Property name="dividerLocation" type="int" value="200"/>
+            <Property name="dividerLocation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="SettingsManager.getInstance().getConfigAsInt(&quot;spellsSplitSize&quot;, &quot;200&quot;)" type="code"/>
+            </Property>
             <Property name="orientation" type="int" value="0"/>
           </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jSplitPane1PropertyChange"/>
+          </Events>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>

--- a/src/gui/tabs/TabFeiticosGui.java
+++ b/src/gui/tabs/TabFeiticosGui.java
@@ -24,7 +24,7 @@ import persistenceCommons.SettingsManager;
  */
 public final class TabFeiticosGui extends TabBase implements Serializable {
 
-    private static final Log log = LogFactory.getLog(TabFeiticosGui.class);
+    private static final Log LOG = LogFactory.getLog(TabFeiticosGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private final FeiticoControler feiticoControl;
 
@@ -81,8 +81,13 @@ public final class TabFeiticosGui extends TabBase implements Serializable {
         qtFeiticos.setText(labels.getString("QTD")); // NOI18N
 
         jSplitPane1.setBorder(null);
-        jSplitPane1.setDividerLocation(200);
+        jSplitPane1.setDividerLocation(SettingsManager.getInstance().getConfigAsInt("spellsSplitSize", "200"));
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
+        jSplitPane1.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                jSplitPane1PropertyChange(evt);
+            }
+        });
 
         jScrollPane3.setBorder(null);
 
@@ -177,6 +182,15 @@ public final class TabFeiticosGui extends TabBase implements Serializable {
             .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void jSplitPane1PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jSplitPane1PropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitHeight = evt.getNewValue().toString();
+            LOG.debug("Split spells pane divisor modified to " + splitHeight + " px.");
+            SettingsManager.getInstance().setConfig("spellsSplitSize", splitHeight);            
+        }
+    }//GEN-LAST:event_jSplitPane1PropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox comboFiltro;
     private javax.swing.JLabel jLabel2;

--- a/src/gui/tabs/TabFinancesGui.form
+++ b/src/gui/tabs/TabFinancesGui.form
@@ -113,12 +113,17 @@
             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
               <Border info="null"/>
             </Property>
-            <Property name="dividerLocation" type="int" value="200"/>
+            <Property name="dividerLocation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="SettingsManager.getInstance().getConfigAsInt(&quot;financesSplitSize&quot;, &quot;200&quot;)" type="code"/>
+            </Property>
             <Property name="dividerSize" type="int" value="3"/>
             <Property name="orientation" type="int" value="0"/>
             <Property name="resizeWeight" type="double" value="0.5"/>
             <Property name="autoscrolls" type="boolean" value="true"/>
           </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jSplitPane1PropertyChange"/>
+          </Events>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>

--- a/src/gui/tabs/TabFinancesGui.java
+++ b/src/gui/tabs/TabFinancesGui.java
@@ -31,7 +31,7 @@ import persistenceCommons.SettingsManager;
  */
 public class TabFinancesGui extends TabBase implements Serializable {
 
-    private static final Log log = LogFactory.getLog(TabFinancesGui.class);
+    private static final Log LOG = LogFactory.getLog(TabFinancesGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private final NacaoFacade nacaoFacade = new NacaoFacade();
     private final CenarioFacade cenarioFacade = new CenarioFacade();
@@ -106,11 +106,16 @@ public class TabFinancesGui extends TabBase implements Serializable {
         );
 
         jSplitPane1.setBorder(null);
-        jSplitPane1.setDividerLocation(200);
+        jSplitPane1.setDividerLocation(SettingsManager.getInstance().getConfigAsInt("financesSplitSize", "200"));
         jSplitPane1.setDividerSize(3);
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
         jSplitPane1.setResizeWeight(0.5);
         jSplitPane1.setAutoscrolls(true);
+        jSplitPane1.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                jSplitPane1PropertyChange(evt);
+            }
+        });
 
         jScrollPane3.setBorder(null);
 
@@ -173,6 +178,15 @@ public class TabFinancesGui extends TabBase implements Serializable {
             .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void jSplitPane1PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jSplitPane1PropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitHeight = evt.getNewValue().toString();
+            LOG.debug("Split finances pane divisor modified to " + splitHeight + " px.");
+            SettingsManager.getInstance().setConfig("financesSplitSize", splitHeight);            
+        } 
+    }//GEN-LAST:event_jSplitPane1PropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox comboFiltro;
     private javax.swing.JTabbedPane detalhesNacao;

--- a/src/gui/tabs/TabNacoesGui.form
+++ b/src/gui/tabs/TabNacoesGui.form
@@ -113,12 +113,17 @@
             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
               <Border info="null"/>
             </Property>
-            <Property name="dividerLocation" type="int" value="200"/>
+            <Property name="dividerLocation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="SettingsManager.getInstance().getConfigAsInt(&quot;nationsSplitSize&quot;, &quot;200&quot;)" type="code"/>
+            </Property>
             <Property name="dividerSize" type="int" value="3"/>
             <Property name="orientation" type="int" value="0"/>
             <Property name="resizeWeight" type="double" value="0.5"/>
             <Property name="autoscrolls" type="boolean" value="true"/>
           </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jSplitPane1PropertyChange"/>
+          </Events>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>

--- a/src/gui/tabs/TabNacoesGui.java
+++ b/src/gui/tabs/TabNacoesGui.java
@@ -41,7 +41,7 @@ import persistenceCommons.SettingsManager;
  */
 public class TabNacoesGui extends TabBase implements Serializable, IAcaoGui {
 
-    private static final Log log = LogFactory.getLog(TabNacoesGui.class);
+    private static final Log LOG = LogFactory.getLog(TabNacoesGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private NacaoControler nacaoControl;
     private static final AcaoFacade acaoFacade = new AcaoFacade();
@@ -122,11 +122,16 @@ public class TabNacoesGui extends TabBase implements Serializable, IAcaoGui {
         );
 
         jSplitPane1.setBorder(null);
-        jSplitPane1.setDividerLocation(200);
+        jSplitPane1.setDividerLocation(SettingsManager.getInstance().getConfigAsInt("nationsSplitSize", "200"));
         jSplitPane1.setDividerSize(3);
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
         jSplitPane1.setResizeWeight(0.5);
         jSplitPane1.setAutoscrolls(true);
+        jSplitPane1.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                jSplitPane1PropertyChange(evt);
+            }
+        });
 
         jScrollPane3.setBorder(null);
 
@@ -189,6 +194,15 @@ public class TabNacoesGui extends TabBase implements Serializable, IAcaoGui {
             .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void jSplitPane1PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jSplitPane1PropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitHeight = evt.getNewValue().toString();
+            LOG.debug("Split nations pane divisor modified to " + splitHeight + " px.");
+            SettingsManager.getInstance().setConfig("nationsSplitSize", splitHeight);            
+        } 
+    }//GEN-LAST:event_jSplitPane1PropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox comboFiltro;
     private javax.swing.JTabbedPane detalhesNacao;

--- a/src/gui/tabs/TabPersonagensGui.form
+++ b/src/gui/tabs/TabPersonagensGui.form
@@ -125,9 +125,14 @@
             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
               <Border info="null"/>
             </Property>
-            <Property name="dividerLocation" type="int" value="200"/>
+            <Property name="dividerLocation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="SysApoio.parseInt(SettingsManager.getInstance().getConfig(&quot;charSplitSize&quot;, &quot;200&quot;))" type="code"/>
+            </Property>
             <Property name="orientation" type="int" value="0"/>
           </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jSplitPane1PropertyChange"/>
+          </Events>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>

--- a/src/gui/tabs/TabPersonagensGui.java
+++ b/src/gui/tabs/TabPersonagensGui.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.LogFactory;
 import persistence.local.WorldManager;
 import persistenceCommons.BundleManager;
 import persistenceCommons.SettingsManager;
+import persistenceCommons.SysApoio;
 import utils.OpenSlotCounter;
 
 /**
@@ -38,7 +39,7 @@ import utils.OpenSlotCounter;
  */
 public class TabPersonagensGui extends TabBase implements Serializable, IAcaoGui {
 
-    private static final Log log = LogFactory.getLog(TabPersonagensGui.class);
+    private static final Log LOG = LogFactory.getLog(TabPersonagensGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private PersonagemControler personagemControl;
     private final PersonagemFacade personagemFacade = new PersonagemFacade();
@@ -125,8 +126,13 @@ public class TabPersonagensGui extends TabBase implements Serializable, IAcaoGui
         );
 
         jSplitPane1.setBorder(null);
-        jSplitPane1.setDividerLocation(200);
+        jSplitPane1.setDividerLocation(SysApoio.parseInt(SettingsManager.getInstance().getConfig("charSplitSize", "200")));
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
+        jSplitPane1.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                jSplitPane1PropertyChange(evt);
+            }
+        });
 
         jScrollPane3.setBorder(null);
         jScrollPane3.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
@@ -233,6 +239,15 @@ public class TabPersonagensGui extends TabBase implements Serializable, IAcaoGui
             .addComponent(jpMaster, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void jSplitPane1PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jSplitPane1PropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitHeight = evt.getNewValue().toString();
+            LOG.debug("Split character pane divisor modified to " + splitHeight + " px.");
+            SettingsManager.getInstance().setConfig("charSplitSize", splitHeight);
+        } 
+    }//GEN-LAST:event_jSplitPane1PropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox comboFiltro;
     private javax.swing.JTabbedPane detalhesPersonagem;

--- a/src/gui/tabs/TabTipoTropasGui.form
+++ b/src/gui/tabs/TabTipoTropasGui.form
@@ -108,12 +108,17 @@
             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
               <Border info="null"/>
             </Property>
-            <Property name="dividerLocation" type="int" value="200"/>
+            <Property name="dividerLocation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="SettingsManager.getInstance().getConfigAsInt(&quot;troopsSplitSize&quot;, &quot;200&quot;)" type="code"/>
+            </Property>
             <Property name="dividerSize" type="int" value="3"/>
             <Property name="orientation" type="int" value="0"/>
             <Property name="resizeWeight" type="double" value="0.5"/>
             <Property name="autoscrolls" type="boolean" value="true"/>
           </Properties>
+          <Events>
+            <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jSplitPane1PropertyChange"/>
+          </Events>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
           <SubComponents>

--- a/src/gui/tabs/TabTipoTropasGui.java
+++ b/src/gui/tabs/TabTipoTropasGui.java
@@ -28,7 +28,7 @@ import persistenceCommons.SettingsManager;
  */
 public class TabTipoTropasGui extends TabBase {
 
-    private static final Log log = LogFactory.getLog(TabTipoTropasGui.class);
+    private static final Log LOG = LogFactory.getLog(TabTipoTropasGui.class);
     private static final BundleManager labels = SettingsManager.getInstance().getBundleManager();
     private TipoTropaControler controler;
 
@@ -107,11 +107,16 @@ public class TabTipoTropasGui extends TabBase {
         );
 
         jSplitPane1.setBorder(null);
-        jSplitPane1.setDividerLocation(200);
+        jSplitPane1.setDividerLocation(SettingsManager.getInstance().getConfigAsInt("troopsSplitSize", "200"));
         jSplitPane1.setDividerSize(3);
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
         jSplitPane1.setResizeWeight(0.5);
         jSplitPane1.setAutoscrolls(true);
+        jSplitPane1.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+            public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                jSplitPane1PropertyChange(evt);
+            }
+        });
 
         jScrollPane3.setBorder(null);
 
@@ -290,6 +295,15 @@ public class TabTipoTropasGui extends TabBase {
                 .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void jSplitPane1PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_jSplitPane1PropertyChange
+        if (evt.getPropertyName().equals(javax.swing.JSplitPane.DIVIDER_LOCATION_PROPERTY) ) {
+            String splitHeight = evt.getNewValue().toString();
+            LOG.debug("Split troops pane divisor modified to " + splitHeight + " px.");
+            SettingsManager.getInstance().setConfig("troopsSplitSize", splitHeight);            
+        } 
+    }//GEN-LAST:event_jSplitPane1PropertyChange
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox comboFiltro;
     private javax.swing.JLabel jLabel1;


### PR DESCRIPTION
* add lib to path

* Try to resolve conflict

* Settings window. First part.

* Settings window. Second part, some labels.

* jspinner in settings

* jspinner in settings

* Settings window.

* Settings window.

* Settings window.

* Update code to 1.6 compatibility.

* Enable and disable auto load action and auto load turn

* Fix forecast

* Fix forecast

* Fix forecast

* Fix forecast

* Fix forecast again. I hate git.

* Fix forecast again. I hate git.

* Merge clashoflegends/master

Conflicts:
	src/gui/MainSettingsGui.form
	src/gui/MainSettingsGui.java

* Merge clashoflegends/master

Conflicts:
	src/gui/MainSettingsGui.form
	src/gui/MainSettingsGui.java

* Merge clashoflegends/master

Conflicts:
	src/gui/MainSettingsGui.form
	src/gui/MainSettingsGui.java

* Merge clashoflegends/master

Conflicts:
	src/gui/MainSettingsGui.form
	src/gui/MainSettingsGui.java

* Merge clashoflegends/master

Conflicts:
	src/gui/MainSettingsGui.form
	src/gui/MainSettingsGui.java

* Merge clashoflegends/master

Conflicts:
	src/gui/MainSettingsGui.form
	src/gui/MainSettingsGui.java

* Check box to display portraits

* Add panel to display portraits

* dispatch manager switch portrait panel

* dispatch manager switch portrait panel

* dispatch manager switch portrait panel

* dispatch manager switch portrait panel

* dispatch manager switch portrait panel

* dispatch manager switch portrait panel

* Load images from folder.

* Show ranks under portrait

* Fix window view for linux

* - Try to fix TabPersonagemGui

* Default portrait 'blank.jpg' for testing purpuse

* Revert "Default portrait 'blank.jpg' for testing purpuse"

This reverts commit 6022d873c41f3abe1ee566f95104887756c78fcc.

* Revert "Revert "Default portrait 'blank.jpg' for testing purpuse""

This reverts commit 3ca59af3ac8aa93fe2235a3d28894d7eb160eff4.

* Revert "Revert "Revert "Default portrait 'blank.jpg' for testing purpuse"""

This reverts commit 01fbd3cc6e922d023d413a6bf8c67043e4812018.

* Revert "- Try to fix TabPersonagemGui"

This reverts commit 5c6e52b6c0de632f1657e1a45df63be543309c82.

* Default portrait 'blank.jpg' for testing purpuse

* - User choose portraits folder.

* - Download portrait file with progress monitor.

* - Download portrait file with progress monitor.

* - Download portrait file with progress monitor.

* - Fix delete zip file after unzip process.

* Try to fix the issue with config window in dual monitor.

* Remove config files

* Remove config files. Commit unchecked

* Remove config files. Commit unchecked

* Restore config files to commit 804ed22

* Remove temp files

* - Fix incorrect jpanel resize for items with long history.

* - Fix incorrect jpanel resize for items with long history.

* - Fix incorrect jpanel resize for items with long history.

* Revert changes

* Reveert

* Manual sync from clash

* - Download folder selector moved
- Fix enable portraits checkbox behavior when portraits folder is accidentall deleted.
- Enable portraits checkbox is correctly enabled when de download process is finished.

* Revert config files

* Revert config files

* Revert unwanted changed file

* Wrap width in the panel of orders.

* Added portrait folder text field in settings window.

* src/control/services/DownloadPortraitsHttpServiceImpl.java

* New toggle buttons added in the main tool bar. To testing.

* Fixed Java version 8 detection.

* Fixed OutOfMemoryException crash when trying to open multiple turn files in the same Counselor instance.

* Fixed radial menu bug introduced by #46.

* The split length of the map is saved when it's modified. Changing this value from the settings pane change the split length of the map (no reboot needed).

* Save the height split for the next tabs:
- Actions tab.
- Magic items tab.
- Cities tab.
- Armies tab.
- Spells tab.
- Finances tab.
- Nations tab.
- Characters tab.
- Troops tab.

Co-authored-by: cladwen <>
Co-authored-by: serguei <serguei@localhost>
Co-authored-by: serguei <serguei@192.168.1.36>